### PR TITLE
Add support for more FiledRequest and Insight Firestore actions

### DIFF
--- a/src/actions/filedRequestActions.ts
+++ b/src/actions/filedRequestActions.ts
@@ -1,17 +1,76 @@
 import { firestore } from '../firebase'
 import {FiledRequest, REQUESTS_COLLECTION} from "../interfaces/filedRequest";
 import {v4 as uuidv4} from 'uuid';
-import {doc, setDoc} from "firebase/firestore";
-import {ORGANIZATIONS_COLLECTION, TEST_ORGANIZATION} from "../interfaces/organization";
-import {GROUPS_COLLECTION, TEST_GROUP} from "../interfaces/group";
+import {
+    doc,
+    setDoc,
+    getDocs,
+    deleteDoc,
+    query,
+    orderBy,
+    limit,
+    collection,
+    startAfter,
+    getDoc
+} from "firebase/firestore";
+import {ORGANIZATIONS_COLLECTION} from "../interfaces/organization";
+import {GROUPS_COLLECTION} from "../interfaces/group";
+import {CollectionReference, Query} from "@firebase/firestore";
 
-export const addFiledRequest = (filedRequest: FiledRequest) => {
-    const uuid = uuidv4()
+const QUERY_LIMIT: number = 100
 
-    setDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${TEST_ORGANIZATION}/${GROUPS_COLLECTION}/${TEST_GROUP}/${REQUESTS_COLLECTION}`, uuid), {
-        //TODO Add FireStore converter for FiledRequest
-    }).then(() => {
+export const addFiledRequest = (organization: string, group: string, filedRequest: FiledRequest) => {
+    const uuid: string = uuidv4()
 
-    });
+    setDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${REQUESTS_COLLECTION}`, uuid), filedRequest)
+        .catch((error) => {
+            console.log("Error - FireStore - Adding FiledRequest: ", error);
+        });
 }
 
+export const updateFiledRequest = (organization: string, group: string, filedRequestId: string, filedRequest: FiledRequest) => {
+    setDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${REQUESTS_COLLECTION}`, filedRequestId), filedRequest)
+        .catch((error) => {
+            console.log("Error - FireStore - Updating FiledRequest: ", error);
+        });
+}
+
+export const getFiledRequest = (organization: string, group: string, filedRequestId: string): FiledRequest | null => {
+    getDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${REQUESTS_COLLECTION}`, filedRequestId))
+        .then((documentSnapshot) => {
+            return documentSnapshot.data() as FiledRequest
+        })
+        .catch((error) => {
+            console.log("Error - FireStore - Getting FiledRequest: ", error);
+        });
+    return null;
+}
+
+export const deleteFiledRequest = (organization: string, group: string, filedRequestId: string) => {
+    deleteDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${REQUESTS_COLLECTION}`, filedRequestId))
+        .catch((error) => {
+            console.log("Error - FireStore - Deleting FiledRequest: ", error);
+        });
+}
+
+export const getFiledRequests = (organization: string, group: string): Map<string, FiledRequest> => {
+    const groupRef: CollectionReference =
+        collection(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${REQUESTS_COLLECTION}`);
+    // TODO Add pagination support, for now just using a limit as a guardrail
+    // TODO Add support for ordering by different combinations of attributes
+    const queryRequest: Query = query(groupRef, orderBy("lastUpdated", "desc"), limit(QUERY_LIMIT), startAfter());
+
+    const filedRequests: Map<string, FiledRequest> = new Map<string, FiledRequest>();
+    getDocs(queryRequest)
+        .then((querySnapshot) => {
+            querySnapshot.forEach((documentSnapshot) => {
+                    filedRequests.set(documentSnapshot.id, documentSnapshot.data() as FiledRequest)
+                }
+            )
+        })
+        .catch((error) => {
+            console.log("Error - FireStore - Querying FiledRequests: ", error);
+        });
+
+    return filedRequests;
+}

--- a/src/actions/insightActions.ts
+++ b/src/actions/insightActions.ts
@@ -1,17 +1,63 @@
-import { firestore } from '../firebase'
+import {firebaseStorage, firestore} from '../firebase'
 import {v4 as uuidv4} from 'uuid';
-import {doc, setDoc} from "firebase/firestore";
-import {ORGANIZATIONS_COLLECTION, TEST_ORGANIZATION} from "../interfaces/organization";
-import {GROUPS_COLLECTION, TEST_GROUP} from "../interfaces/group";
+import {doc, setDoc, getDoc, deleteDoc} from "firebase/firestore";
+import {uploadBytes, ref, getDownloadURL} from "firebase/storage";
+import {ORGANIZATIONS_COLLECTION} from "../interfaces/organization";
+import {GROUPS_COLLECTION} from "../interfaces/group";
 import {Insight, INSIGHTS_COLLECTION} from "../interfaces/insight";
+import {UploadMetadata} from "@firebase/storage";
 
-export const addInsight = (insight: Insight) => {
+export const addInsight = (organization: string, group: string, insight: Insight) => {
     const uuid = uuidv4()
 
-    setDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${TEST_ORGANIZATION}/${GROUPS_COLLECTION}/${TEST_GROUP}/${INSIGHTS_COLLECTION}`, uuid), {
-        //TODO Add FireStore converter for Insight
-    }).then(() => {
+    setDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${INSIGHTS_COLLECTION}`, uuid), {insight})
+        .catch((error) => {
+            console.log("Error - FireStore - Adding Insight: ", error);
+        });
+}
 
+export const updateInsight = (organization: string, group: string, insightId: string, insight: Insight) => {
+    setDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${INSIGHTS_COLLECTION}`, insightId), insight)
+        .catch((error) => {
+            console.log("Error - FireStore - Updating Insight: ", error);
+        });
+}
+
+export const getInsight = (organization: string, group: string, insightId: string): Insight | null => {
+    getDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${INSIGHTS_COLLECTION}`, insightId))
+        .then((documentSnapshot) => {
+            return documentSnapshot.data() as Insight
+        })
+        .catch((error) => {
+            console.log("Error - FireStore - Getting Insight: ", error);
+        });
+    return null;
+}
+
+export const deleteInsight = (organization: string, group: string, insightId: string) => {
+    deleteDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${INSIGHTS_COLLECTION}`, insightId)).catch((error) => {
+        console.log("Error - FireStore - Deleting Insight: ", error);
     });
 }
 
+export const storeInsightMedia = (imageFile: File): string | null => {
+    const uuid = uuidv4()
+    const metadata: UploadMetadata = {
+        contentType: 'image/jpeg',
+    };
+
+    uploadBytes(ref(firebaseStorage, uuid), imageFile, metadata)
+        .then((uploadResult) => {
+            getDownloadURL(uploadResult.ref)
+                .then((downloadURL: string) => {
+                    return downloadURL
+                })
+                .catch((error) => {
+                    console.log("Error - FirebaseStorage - Getting Insight file URLs", error);
+                });
+            })
+        .catch((error) => {
+            console.log("Error - FirebaseStorage - Upload Insight files", error);
+        });
+    return null;
+}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
     apiKey: "AIzaSyCSo1nRkbvdenMURWhy8DOfPeW03FCtTuc",
@@ -14,5 +15,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const firebaseApp = initializeApp(firebaseConfig);
 const firestore = getFirestore(firebaseApp);
+const firebaseStorage = getStorage(firebaseApp);
 
-export {firebaseApp, firestore}
+export {firebaseApp, firestore, firebaseStorage}

--- a/src/interfaces/filedRequest.ts
+++ b/src/interfaces/filedRequest.ts
@@ -5,10 +5,11 @@ import {Group} from "./group";
 export const REQUESTS_COLLECTION = "requests"
 
 export interface FiledRequest {
-    createdBy: User;
+    createdBy: string;
     createDate: number;
+    lastUpdated: number;
     title: string;
-    assignee: User | Group;
+    assignee: string; // userId || groupId
     priority: RequestPriority;
     status: RequestStatus;
     deadline: number;
@@ -17,7 +18,7 @@ export interface FiledRequest {
     project?: string; // TODO Add project type
     description?: string;
     comments?: string[];
-    insights? : Insight[]
+    insights? : string[] // insightIds
 }
 
 type RequestPriority = "Low" | "Medium" | "High"

--- a/src/interfaces/insight.ts
+++ b/src/interfaces/insight.ts
@@ -4,11 +4,11 @@ import {User} from "./user";
 export const INSIGHTS_COLLECTION = "insights"
 
 export interface Insight {
-    createdBy: User;
+    createdBy: string; // userId
     createDate: number;
     title: string;
-    request: FiledRequest;
-    collaborators: User[];
+    request: string[]; // filedRequestIds
+    collaborators: string[] // userIds/groupsIds;
     description?: string;
     attachments?: string[]; // TODO Support complex media types
     repositoryUrl?: string;


### PR DESCRIPTION
- Add core CRUD Firestore functionality for FiledRequests and Insights
- Add basic support for FirbaseStorage as a means to store uploaded insight media
- Will look to make a plan and expand on querying patterns and pagination