### PR TITLE
Core Groups Functionality - Support switching between groups, users creating/leaving

### DIFF
--- a/interfaces/user.ts
+++ b/interfaces/user.ts
@@ -1,4 +1,6 @@
 export const USERS_COLLECTION = "users"
+export const TEST_USER = "TEST_USER"
+
 export interface User {
     organizationId: string;
     groupsIds: string[]

--- a/src/actions/filedRequestActions.ts
+++ b/src/actions/filedRequestActions.ts
@@ -16,8 +16,6 @@ import {ORGANIZATIONS_COLLECTION} from "@interfaces/organization";
 import {GROUPS_COLLECTION} from "@interfaces/group";
 import {CollectionReference, Query} from "@firebase/firestore";
 import firebase from "firebase/compat";
-import QuerySnapshot = firebase.firestore.QuerySnapshot;
-import DocumentData = firebase.firestore.DocumentData;
 
 const QUERY_LIMIT: number = 100
 
@@ -40,19 +38,19 @@ export const updateFiledRequest = (organization: string, group: string, filedReq
         });
 }
 
-export const getFiledRequest = async (organization: string, group: string, filedRequestId: string): Promise<FiledRequest | undefined> => {
+export const getFiledRequest = async (organization: string, group: string, filedRequestId: string): Promise<FiledRequest> => {
     try {
         const filedRequestDocument =
             await getDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${REQUESTS_COLLECTION}`, filedRequestId));
         if (filedRequestDocument.exists()) {
             return filedRequestDocument.data() as FiledRequest
-        } else {
-            console.log("Error - FireStore - Getting FiledRequest: No filed request found for id: " + filedRequestId)
         }
     } catch (error: unknown) {
         console.log("Error - FireStore - Getting FiledRequest: ", error);
         throw error
     }
+    console.log("Error - FireStore - Getting FiledRequest: No filed request found for id: " + filedRequestId)
+    throw new Error();
 }
 
 export const deleteFiledRequest = async (organization: string, group: string, filedRequestId: string) => {

--- a/src/actions/insightActions.ts
+++ b/src/actions/insightActions.ts
@@ -39,19 +39,19 @@ export const updateInsight = (organization: string, group: string, insightId: st
         });
 }
 
-export const getInsight = async (organization: string, group: string, insightId: string): Promise<Insight | undefined> => {
+export const getInsight = async (organization: string, group: string, insightId: string): Promise<Insight> => {
     try {
         const insightDocument =
             await getDoc(doc(firestore, `${ORGANIZATIONS_COLLECTION}/${organization}/${GROUPS_COLLECTION}/${group}/${INSIGHTS_COLLECTION}`, insightId))
         if (insightDocument.exists()) {
             return insightDocument.data() as Insight
-        } else {
-            console.log("Error - FireStore - Getting Insight: No insight found for id: " + insightId)
         }
     } catch (error: unknown) {
         console.log("Error - FireStore - Getting Insight: ", error);
         throw error
     }
+    console.log("Error - FireStore - Getting Insight: No insight found for id: " + insightId);
+    throw new Error();
 }
 
 export const deleteInsight = async (organization: string, group: string, insightId: string) => {

--- a/src/actions/userActions.ts
+++ b/src/actions/userActions.ts
@@ -1,4 +1,4 @@
-import {arrayRemove, arrayUnion, doc, getDoc, setDoc, updateDoc} from "firebase/firestore";
+import {doc, getDoc} from "firebase/firestore";
 import {firestore} from "../firebase";
 import {User, USERS_COLLECTION} from "@interfaces/user";
 
@@ -7,34 +7,11 @@ export const getUser = async (userId: string): Promise<User> => {
         const userIdDocument = await getDoc(doc(firestore, USERS_COLLECTION, userId));
         if (userIdDocument.exists()) {
             return userIdDocument.data() as User
-        } else {
-            console.log("Error - FireStore - Getting User: No user found for id: " + userId)
-            throw new Error();
         }
     } catch (error: unknown) {
         console.log("Error - FireStore - Getting User: ", error);
         throw error
     }
-}
-
-export const addUserToGroup = async (userId: string, groupName: string) => {
-    try {
-        await updateDoc(doc(firestore, USERS_COLLECTION, userId), {
-            groupsIds: arrayUnion(groupName)
-        });
-    } catch (error: unknown) {
-        console.log("Error - FireStore - Adding user to group: ", error);
-        throw error
-    }
-}
-
-export const removeUserFromGroup = async (userId: string, groupName: string) => {
-    try {
-        await updateDoc(doc(firestore, USERS_COLLECTION, userId), {
-            groupsIds: arrayRemove(groupName)
-        });
-    } catch (error: unknown) {
-        console.log("Error - FireStore - Removing user from group: ", error);
-        throw error
-    }
+    console.log("Error - FireStore - Getting User: No user found for id: " + userId)
+    throw new Error();
 }

--- a/src/actions/userActions.ts
+++ b/src/actions/userActions.ts
@@ -1,0 +1,40 @@
+import {arrayRemove, arrayUnion, doc, getDoc, setDoc, updateDoc} from "firebase/firestore";
+import {firestore} from "../firebase";
+import {User, USERS_COLLECTION} from "@interfaces/user";
+
+export const getUser = async (userId: string): Promise<User> => {
+    try {
+        const userIdDocument = await getDoc(doc(firestore, USERS_COLLECTION, userId));
+        if (userIdDocument.exists()) {
+            return userIdDocument.data() as User
+        } else {
+            console.log("Error - FireStore - Getting User: No user found for id: " + userId)
+            throw new Error();
+        }
+    } catch (error: unknown) {
+        console.log("Error - FireStore - Getting User: ", error);
+        throw error
+    }
+}
+
+export const addUserToGroup = async (userId: string, groupName: string) => {
+    try {
+        await updateDoc(doc(firestore, USERS_COLLECTION, userId), {
+            groupsIds: arrayUnion(groupName)
+        });
+    } catch (error: unknown) {
+        console.log("Error - FireStore - Adding user to group: ", error);
+        throw error
+    }
+}
+
+export const removeUserFromGroup = async (userId: string, groupName: string) => {
+    try {
+        await updateDoc(doc(firestore, USERS_COLLECTION, userId), {
+            groupsIds: arrayRemove(groupName)
+        });
+    } catch (error: unknown) {
+        console.log("Error - FireStore - Removing user from group: ", error);
+        throw error
+    }
+}

--- a/src/api/addUserToGroup.ts
+++ b/src/api/addUserToGroup.ts
@@ -1,0 +1,14 @@
+import {arrayUnion, doc, updateDoc} from "firebase/firestore";
+import {firestore} from "../firebase";
+import {USERS_COLLECTION} from "@interfaces/user";
+
+export const addUserToGroup = async (userId: string, groupName: string) => {
+    try {
+        await updateDoc(doc(firestore, USERS_COLLECTION, userId), {
+            groupsIds: arrayUnion(groupName)
+        });
+    } catch (error: unknown) {
+        console.log("Error - FireStore - Adding user to group: ", error);
+        throw error
+    }
+}

--- a/src/api/removeUserFromGroup.ts
+++ b/src/api/removeUserFromGroup.ts
@@ -1,0 +1,14 @@
+import {arrayRemove, doc, updateDoc} from "firebase/firestore";
+import {firestore} from "../firebase";
+import {USERS_COLLECTION} from "@interfaces/user";
+
+export const removeUserFromGroup = async (userId: string, groupName: string) => {
+    try {
+        await updateDoc(doc(firestore, USERS_COLLECTION, userId), {
+            groupsIds: arrayRemove(groupName)
+        });
+    } catch (error: unknown) {
+        console.log("Error - FireStore - Removing user from group: ", error);
+        throw error
+    }
+}


### PR DESCRIPTION
- Display list of groups of current user (user currently hardcoded)
- Support switching between groups
- Basic implementation of creating groups. Will need to support creating group metadata object, currently group creation only modifies stored user object
- Support user leaving groups, deletion of groups will be a bit nuanced as Firestore has some best practices for guardrails for deleting entire subcollections
- Added some crude UI for group inputs, made a hacky temporary change to zIndex to force visibility of the core dashboard components